### PR TITLE
Workaround for icon libraries like glyphicons, constructor with PDRectangle

### DIFF
--- a/src/main/java/org/fit/cssbox/render/PDFRenderer.java
+++ b/src/main/java/org/fit/cssbox/render/PDFRenderer.java
@@ -148,6 +148,17 @@ public class PDFRenderer implements BoxRenderer
                 break;
         }
         
+        initSettings(rootWidth);
+    }
+    public PDFRenderer(int rootWidth, int rootHeight, OutputStream out, PDRectangle pageFormat) {
+        this.rootHeight = rootHeight;
+        this.pathToSave = out;
+        this.pageCount = 0;
+        this.pageFormat = pageFormat;
+        initSettings(rootWidth);
+    }
+
+    private void initSettings(int rootWidth) {
         // calculate resize coefficient
         resCoef = this.pageFormat.getWidth()/rootWidth;
         

--- a/src/main/java/org/fit/cssbox/render/PDFRenderer.java
+++ b/src/main/java/org/fit/cssbox/render/PDFRenderer.java
@@ -1393,6 +1393,8 @@ public class PDFRenderer implements BoxRenderer
             try {
                 content.showText(textToInsert);
             } catch (IllegalArgumentException e) {
+                // NOTE: seems to happen for embedded icon fonts like glyphicons and fa, add space so there is some text otherwise PDFBox throws IllegalStateException: subset is empty; these work with SVGRenderer
+                content.showText(" ");
                 System.err.println("Error: " + e.getMessage());
             }
             content.endText();


### PR DESCRIPTION
When using icon libraries like glyphicons there will be characters that are invalid in any other font resulting in an IllegalStateException because when an exception is thrown the writeTextPDFBox() method effectively does not call showText() at all before calling endText(). In this change a space is added so there is still some text there (I suppose a question mark could be added so developers know something is wrong, this is just cleaner).

The other change is a constructor that accepts a PDRectangle instead of a String for the pageFormat, allowing more flexibility when other standard or custom page sizes are needed.

On a side note, we are experimentally using this in Moqui Framework for server-side HTML rendering. You can see the code in the moqui/moqui-fop repository here on GitHub. More specifically, here is the HtmlRenderer class that uses CSSBox and CSSBoxPdf:

https://github.com/moqui/moqui-fop/blob/master/src/main/groovy/org/moqui/fop/HtmlRenderer.groovy

This class is loosely based on your demo code. There is also a servlet in the same package for streaming results, but just a warning it has code that is specific to Moqui Framework (ie the server side HTML generation, parameter handling, etc). All of this is open source so feel free to use or ask about anything of interest.
